### PR TITLE
ci(lint): fix linter for multi-module repo

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,9 @@ jobs:
   golangci:
     name: golangci
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        modules: [ ".", "./functions/src/data/init", "./functions/src/data/fetch", "./functions/src/data/load", "./functions/src/handlers/lookup"]
     steps:
       - uses: actions/setup-go@v3
         with:
@@ -23,7 +26,7 @@ jobs:
           version: latest
 
           # Optional: working directory, useful for monorepos
-          # working-directory: somedir
+          working-directory: ${{ matrix.modules }}
 
           # Optional: golangci-lint command line arguments.
           args: -E misspell -E revive -E bodyclose -E errname -E gofmt --timeout=5m

--- a/functions/src/data/fetch/main.go
+++ b/functions/src/data/fetch/main.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/tarmac-project/tarmac/pkg/sdk"
 )
 

--- a/functions/src/data/init/main.go
+++ b/functions/src/data/init/main.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/tarmac-project/tarmac/pkg/sdk"
 )
 

--- a/functions/src/data/load/main.go
+++ b/functions/src/data/load/main.go
@@ -1,8 +1,8 @@
 /*
-The purpose of this function is to download the CSV data (by calling another function), parse it, enrich the data, and 
+The purpose of this function is to download the CSV data (by calling another function), parse it, enrich the data, and
 load the contents within the SQL database.
 
-This function is called multiple times throughout the application. It's called by an "init" function and also set 
+This function is called multiple times throughout the application. It's called by an "init" function and also set
 as a scheduled task by itself.
 */
 package main
@@ -10,9 +10,10 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"html"
+
 	"github.com/tarmac-project/example-airport-lookup-go/pkg/airport/parsers/csv"
 	"github.com/tarmac-project/tarmac/pkg/sdk"
-	"html"
 )
 
 type Function struct {

--- a/functions/src/handlers/lookup/main.go
+++ b/functions/src/handlers/lookup/main.go
@@ -1,6 +1,6 @@
 /*
-This function is a lookup request handler function. When a request is received, this function is called and will parse 
-the incoming request, look up the requested airport from the cache, on cache miss, find the requested data in the 
+This function is a lookup request handler function. When a request is received, this function is called and will parse
+the incoming request, look up the requested airport from the cache, on cache miss, find the requested data in the
 database, and provide it back as a response to the request.
 */
 package main
@@ -8,9 +8,10 @@ package main
 import (
 	"encoding/base64"
 	"fmt"
+	"html"
+
 	"github.com/tarmac-project/tarmac/pkg/sdk"
 	"github.com/valyala/fastjson"
-	"html"
 )
 
 // Function is the main function object that will be initialized

--- a/pkg/airport/airport.go
+++ b/pkg/airport/airport.go
@@ -2,6 +2,7 @@ package airport
 
 import (
 	"fmt"
+
 	"github.com/enescakir/emoji"
 )
 

--- a/pkg/airport/parsers/csv/csv.go
+++ b/pkg/airport/parsers/csv/csv.go
@@ -3,8 +3,9 @@ package csv
 import (
 	"encoding/csv"
 	"fmt"
-	"github.com/tarmac-project/example-airport-lookup-go/pkg/airport"
 	"io"
+
+	"github.com/tarmac-project/example-airport-lookup-go/pkg/airport"
 )
 
 var (

--- a/pkg/airport/parsers/csv/csv_test.go
+++ b/pkg/airport/parsers/csv/csv_test.go
@@ -2,10 +2,11 @@ package csv
 
 import (
 	"bytes"
-	"github.com/enescakir/emoji"
-	"github.com/tarmac-project/example-airport-lookup-go/pkg/airport"
 	"reflect"
 	"testing"
+
+	"github.com/enescakir/emoji"
+	"github.com/tarmac-project/example-airport-lookup-go/pkg/airport"
 )
 
 type RecordToAirportTestCase struct {


### PR DESCRIPTION
Currently, golangci-lint is not checking sub-directories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Improved CI linting process for better code quality checks across different modules.
- **Refactor**
	- Added empty lines after import statements in multiple files for better code readability.
- **New Features**
	- Added import statements for "html" and "emoji" packages in relevant files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->