### PR TITLE
chore(deps): adopt released protobuf chain

### DIFF
--- a/functions/src/data/fetch/go.mod
+++ b/functions/src/data/fetch/go.mod
@@ -10,6 +10,6 @@ require (
 
 require (
 	github.com/aperturerobotics/protobuf-go-lite v0.11.0 // indirect
-	github.com/tarmac-project/protobuf-go v0.0.0-20251018194459-da5e9a58aa3f // indirect
+	github.com/tarmac-project/protobuf-go v0.1.0 // indirect
 	github.com/wapc/wapc-guest-tinygo v0.3.3 // indirect
 )

--- a/functions/src/data/fetch/go.sum
+++ b/functions/src/data/fetch/go.sum
@@ -2,8 +2,8 @@ github.com/aperturerobotics/protobuf-go-lite v0.11.0 h1:IAaZISqrEpodqECYxk0yKWgR
 github.com/aperturerobotics/protobuf-go-lite v0.11.0/go.mod h1:c4kGy7Dkfz6B1m0t4QBIMQoNeQ7m+nYj3Qxxnlwhygo=
 github.com/madflojo/testlazy/things/testurl v1.2.0 h1:yQkEX4L2dQkxEG6eii/cGIIpeAScw8s4kvYy8vFjiBA=
 github.com/madflojo/testlazy/things/testurl v1.2.0/go.mod h1:Kj/KFM34bvfnmaDzB+9IOGCxtsWwjymxomFJkBZEb8w=
-github.com/tarmac-project/protobuf-go v0.0.0-20251018194459-da5e9a58aa3f h1:ej3NiKuKuy8QT1z5v664VVwgSymWu0s9iQh1DeCzArY=
-github.com/tarmac-project/protobuf-go v0.0.0-20251018194459-da5e9a58aa3f/go.mod h1:ZF7p3bE27AqFkb5JeOsnIPZAiihzggZjgOlyPLdiF40=
+github.com/tarmac-project/protobuf-go v0.1.0 h1:d3JPVVFejEQvYFM8eZWhnn2Ops8d7pShJP5cTohcCUA=
+github.com/tarmac-project/protobuf-go v0.1.0/go.mod h1:ZF7p3bE27AqFkb5JeOsnIPZAiihzggZjgOlyPLdiF40=
 github.com/tarmac-project/sdk v0.2.0 h1:pdqigefrrUjVT0pFEPBbdw4m5nHEInccZovirMbjnBo=
 github.com/tarmac-project/sdk v0.2.0/go.mod h1:G1FkDLzCzIuAhKbCfzbqeOpB3eBAS0tmMCeb5q0ID0s=
 github.com/tarmac-project/sdk/hostmock v0.1.1 h1:jXpfWJl5C7DHZve5r9gPcZMXA/rTkCYQjQnNznvZQdk=

--- a/functions/src/data/init/go.mod
+++ b/functions/src/data/init/go.mod
@@ -11,6 +11,6 @@ require (
 
 require (
 	github.com/aperturerobotics/protobuf-go-lite v0.11.0 // indirect
-	github.com/tarmac-project/protobuf-go v0.0.0-20251018194459-da5e9a58aa3f // indirect
+	github.com/tarmac-project/protobuf-go v0.1.0 // indirect
 	github.com/wapc/wapc-guest-tinygo v0.3.3 // indirect
 )

--- a/functions/src/data/init/go.sum
+++ b/functions/src/data/init/go.sum
@@ -1,7 +1,7 @@
 github.com/aperturerobotics/protobuf-go-lite v0.11.0 h1:IAaZISqrEpodqECYxk0yKWgROEbZtMhs7bErP+Zma9o=
 github.com/aperturerobotics/protobuf-go-lite v0.11.0/go.mod h1:c4kGy7Dkfz6B1m0t4QBIMQoNeQ7m+nYj3Qxxnlwhygo=
-github.com/tarmac-project/protobuf-go v0.0.0-20251018194459-da5e9a58aa3f h1:ej3NiKuKuy8QT1z5v664VVwgSymWu0s9iQh1DeCzArY=
-github.com/tarmac-project/protobuf-go v0.0.0-20251018194459-da5e9a58aa3f/go.mod h1:ZF7p3bE27AqFkb5JeOsnIPZAiihzggZjgOlyPLdiF40=
+github.com/tarmac-project/protobuf-go v0.1.0 h1:d3JPVVFejEQvYFM8eZWhnn2Ops8d7pShJP5cTohcCUA=
+github.com/tarmac-project/protobuf-go v0.1.0/go.mod h1:ZF7p3bE27AqFkb5JeOsnIPZAiihzggZjgOlyPLdiF40=
 github.com/tarmac-project/sdk v0.2.0 h1:pdqigefrrUjVT0pFEPBbdw4m5nHEInccZovirMbjnBo=
 github.com/tarmac-project/sdk v0.2.0/go.mod h1:G1FkDLzCzIuAhKbCfzbqeOpB3eBAS0tmMCeb5q0ID0s=
 github.com/tarmac-project/sdk/function v0.2.0 h1:QVNY8alhDvIVESU2EIwgqicUUcFnJlKubxgTjIvzQLs=

--- a/functions/src/data/load/go.mod
+++ b/functions/src/data/load/go.mod
@@ -13,6 +13,6 @@ require (
 require (
 	github.com/aperturerobotics/protobuf-go-lite v0.11.0 // indirect
 	github.com/enescakir/emoji v1.0.0 // indirect
-	github.com/tarmac-project/protobuf-go v0.0.0-20251018194459-da5e9a58aa3f // indirect
+	github.com/tarmac-project/protobuf-go v0.1.0 // indirect
 	github.com/wapc/wapc-guest-tinygo v0.3.3 // indirect
 )

--- a/functions/src/data/load/go.sum
+++ b/functions/src/data/load/go.sum
@@ -4,8 +4,8 @@ github.com/enescakir/emoji v1.0.0 h1:W+HsNql8swfCQFtioDGDHCHri8nudlK1n5p2rHCJoog
 github.com/enescakir/emoji v1.0.0/go.mod h1:Bt1EKuLnKDTYpLALApstIkAjdDrS/8IAgTkKp+WKFD0=
 github.com/tarmac-project/example-airport-lookup-go v0.0.0-20231023010400-e4b3efdea82f h1:XhPXDWSza1ae0WBqq3iwRGR5N2/x5W0gFamNULathXM=
 github.com/tarmac-project/example-airport-lookup-go v0.0.0-20231023010400-e4b3efdea82f/go.mod h1:mpM+9904v8UU6HzL/giS7yLzuGvezbDQvdKw6byxO80=
-github.com/tarmac-project/protobuf-go v0.0.0-20251018194459-da5e9a58aa3f h1:ej3NiKuKuy8QT1z5v664VVwgSymWu0s9iQh1DeCzArY=
-github.com/tarmac-project/protobuf-go v0.0.0-20251018194459-da5e9a58aa3f/go.mod h1:ZF7p3bE27AqFkb5JeOsnIPZAiihzggZjgOlyPLdiF40=
+github.com/tarmac-project/protobuf-go v0.1.0 h1:d3JPVVFejEQvYFM8eZWhnn2Ops8d7pShJP5cTohcCUA=
+github.com/tarmac-project/protobuf-go v0.1.0/go.mod h1:ZF7p3bE27AqFkb5JeOsnIPZAiihzggZjgOlyPLdiF40=
 github.com/tarmac-project/sdk v0.2.0 h1:pdqigefrrUjVT0pFEPBbdw4m5nHEInccZovirMbjnBo=
 github.com/tarmac-project/sdk v0.2.0/go.mod h1:G1FkDLzCzIuAhKbCfzbqeOpB3eBAS0tmMCeb5q0ID0s=
 github.com/tarmac-project/sdk/function v0.2.0 h1:QVNY8alhDvIVESU2EIwgqicUUcFnJlKubxgTjIvzQLs=

--- a/functions/src/data/seed/go.mod
+++ b/functions/src/data/seed/go.mod
@@ -10,6 +10,6 @@ require (
 
 require (
 	github.com/aperturerobotics/protobuf-go-lite v0.11.0 // indirect
-	github.com/tarmac-project/protobuf-go v0.0.0-20251018194459-da5e9a58aa3f // indirect
+	github.com/tarmac-project/protobuf-go v0.1.0 // indirect
 	github.com/wapc/wapc-guest-tinygo v0.3.3 // indirect
 )

--- a/functions/src/data/seed/go.sum
+++ b/functions/src/data/seed/go.sum
@@ -1,7 +1,7 @@
 github.com/aperturerobotics/protobuf-go-lite v0.11.0 h1:IAaZISqrEpodqECYxk0yKWgROEbZtMhs7bErP+Zma9o=
 github.com/aperturerobotics/protobuf-go-lite v0.11.0/go.mod h1:c4kGy7Dkfz6B1m0t4QBIMQoNeQ7m+nYj3Qxxnlwhygo=
-github.com/tarmac-project/protobuf-go v0.0.0-20251018194459-da5e9a58aa3f h1:ej3NiKuKuy8QT1z5v664VVwgSymWu0s9iQh1DeCzArY=
-github.com/tarmac-project/protobuf-go v0.0.0-20251018194459-da5e9a58aa3f/go.mod h1:ZF7p3bE27AqFkb5JeOsnIPZAiihzggZjgOlyPLdiF40=
+github.com/tarmac-project/protobuf-go v0.1.0 h1:d3JPVVFejEQvYFM8eZWhnn2Ops8d7pShJP5cTohcCUA=
+github.com/tarmac-project/protobuf-go v0.1.0/go.mod h1:ZF7p3bE27AqFkb5JeOsnIPZAiihzggZjgOlyPLdiF40=
 github.com/tarmac-project/sdk v0.2.0 h1:pdqigefrrUjVT0pFEPBbdw4m5nHEInccZovirMbjnBo=
 github.com/tarmac-project/sdk v0.2.0/go.mod h1:G1FkDLzCzIuAhKbCfzbqeOpB3eBAS0tmMCeb5q0ID0s=
 github.com/tarmac-project/sdk/hostmock v0.1.1 h1:jXpfWJl5C7DHZve5r9gPcZMXA/rTkCYQjQnNznvZQdk=

--- a/functions/src/handlers/lookup/go.mod
+++ b/functions/src/handlers/lookup/go.mod
@@ -12,6 +12,6 @@ require (
 
 require (
 	github.com/aperturerobotics/protobuf-go-lite v0.11.0 // indirect
-	github.com/tarmac-project/protobuf-go v0.0.0-20251018194459-da5e9a58aa3f // indirect
+	github.com/tarmac-project/protobuf-go v0.1.0 // indirect
 	github.com/wapc/wapc-guest-tinygo v0.3.3 // indirect
 )

--- a/functions/src/handlers/lookup/go.sum
+++ b/functions/src/handlers/lookup/go.sum
@@ -1,7 +1,7 @@
 github.com/aperturerobotics/protobuf-go-lite v0.11.0 h1:IAaZISqrEpodqECYxk0yKWgROEbZtMhs7bErP+Zma9o=
 github.com/aperturerobotics/protobuf-go-lite v0.11.0/go.mod h1:c4kGy7Dkfz6B1m0t4QBIMQoNeQ7m+nYj3Qxxnlwhygo=
-github.com/tarmac-project/protobuf-go v0.0.0-20251018194459-da5e9a58aa3f h1:ej3NiKuKuy8QT1z5v664VVwgSymWu0s9iQh1DeCzArY=
-github.com/tarmac-project/protobuf-go v0.0.0-20251018194459-da5e9a58aa3f/go.mod h1:ZF7p3bE27AqFkb5JeOsnIPZAiihzggZjgOlyPLdiF40=
+github.com/tarmac-project/protobuf-go v0.1.0 h1:d3JPVVFejEQvYFM8eZWhnn2Ops8d7pShJP5cTohcCUA=
+github.com/tarmac-project/protobuf-go v0.1.0/go.mod h1:ZF7p3bE27AqFkb5JeOsnIPZAiihzggZjgOlyPLdiF40=
 github.com/tarmac-project/sdk v0.2.0 h1:pdqigefrrUjVT0pFEPBbdw4m5nHEInccZovirMbjnBo=
 github.com/tarmac-project/sdk v0.2.0/go.mod h1:G1FkDLzCzIuAhKbCfzbqeOpB3eBAS0tmMCeb5q0ID0s=
 github.com/tarmac-project/sdk/hostmock v0.1.1 h1:jXpfWJl5C7DHZve5r9gPcZMXA/rTkCYQjQnNznvZQdk=


### PR DESCRIPTION
## Summary
Update the example function modules so they consume the released protobuf dependency chain instead of the old pseudo-version path.

## Changes
- update the function module `go.mod` files to `github.com/tarmac-project/protobuf-go v0.1.0`
- refresh the matching `go.sum` files
- keep the example aligned with the published SDK dependency chain

## Validation
- `go test ./...`
- per-function module `go test ./...` for the updated function modules

## Risk & Impact
- Breaking changes: no user-facing code changes; dependency pin update only
- Performance/Security: removes the pseudo-version dependency from the example path
